### PR TITLE
Read translated po

### DIFF
--- a/POFileType.js
+++ b/POFileType.js
@@ -57,10 +57,7 @@ var POFileType = function(project) {
 };
 
 var defaultMappings = {
-    "**/en.po": {
-        template: "[dir]/[locale].po"
-    },
-    "**/en-*.po": {
+    "**/*.po": {
         template: "[dir]/[locale].po"
     },
     "**/*.pot": {

--- a/README.md
+++ b/README.md
@@ -196,6 +196,16 @@ file for more details.
 
 ## Release Notes
 
+### v1.0.1
+
+- Make this plugin able to read already-localized po files
+  The output file name template is used to construct a regular expression to 
+  recognize already localized files and what the locale of that file is. 
+  Without the template, the locale was never extracted and the source and 
+  target were both en-US which is not correct. This was a bigger problem
+  for those languages where the plural resources have more plural categories
+  than in English, such as Russian or Polish.
+
 ### v1.0.0
 
 - initial version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-po",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "main": "./POFileType.js",
     "description": "A loctool plugin that knows how to localize GNU po and pot files",
     "license": "Apache-2.0",


### PR DESCRIPTION
Make this plugin able to read already-localized po files
  The output file name template is used to construct a regular expression to 
  recognize already localized files and what the locale of that file is. 
  Without the template, the locale was never extracted and the source and 
  target were both en-US which is not correct. This was a bigger problem
  for those languages where the plural resources have more plural categories
  than in English, such as Russian or Polish.