### PR TITLE
Add write method to make the po plugin into a resource file type

### DIFF
--- a/POFile.js
+++ b/POFile.js
@@ -30,10 +30,12 @@ var pluralForms = require("./pluralforms.json");
 var logger = log4js.getLogger("loctool.plugin.POFile");
 
 function escapeQuotes(str) {
+    if (!str) return "";
     return str ? str.replace(/"/g, '\\"') : str;
 }
 
 function unescapeQuotes(str) {
+    if (!str) return "";
     return str ? str.replace(/\\"/g, '"') : str;
 }
 
@@ -453,8 +455,75 @@ POFile.prototype.getTranslationSet = function() {
     return this.set;
 }
 
-//we don't write PO source files
-POFile.prototype.write = function() {};
+/**
+ * Write the resource file out to disk again.
+ */
+POFile.prototype.write = function() {
+    var pathName = this.pathName || this.getLocalizedPath(this.localeSpec);
+    logger.debug("Writing file " + pathName);
+    var p = path.join(this.project.target, pathName);
+    var d = path.dirname(p);
+    this.API.utils.makeDirs(d);
+
+    fs.writeFileSync(p, this.localizeText(undefined, this.localeSpec), "utf-8");
+};
+
+/**
+ * Add a resource to this file. The locale of the resource
+ * should correspond to the locale of the file, and the
+ * context of the resource should match the context of
+ * the file.
+ *
+ * @param {Resource} res a resource to add to this file
+ */
+POFile.prototype.addResource = function(res) {
+    logger.trace("POFile.addResource: " + JSON.stringify(res) + " to " + this.project.getProjectId() + ", " + this.locale + ", " + JSON.stringify(this.context));
+    var resLocale = res.getTargetLocale();
+    if (res && res.getProject() === this.project.getProjectId()) {
+        logger.trace("correct project. Adding.");
+        if (resLocale && resLocale !== this.localeSpec) {
+            // This one is not the right locale, so add it as a source-only resource
+            // so that it can be a placeholder for the real translation later on
+            this.set.add(this.API.newResource({
+                resType: res.getType(),
+                sourcePlurals: (res.getType() === "plural") ? res.getSourcePlurals() : undefined,
+                source: (res.getType() === "string") ? res.getSource() : undefined,
+                sourceLocale: res.getSourceLocale(),
+                project: res.getProject(),
+                key: res.getKey(),
+                pathName: res.getPath(),
+                state: "new",
+                comment: res.getComment(),
+                datatype: this.type.datatype,
+                context: res.getContext(),
+                index: this.resourceIndex++
+            }));
+        } else {
+            this.set.add(res);
+        }
+    } else {
+        if (res) {
+            if (res.getProject() !== this.project.getProjectId()) {
+                logger.warn("Attempt to add a resource to a resource file with the incorrect project.");
+            } else {
+                logger.warn("Attempt to add a resource to a resource file with the incorrect locale. " + resLocale + " vs. " + this.localeSpec);
+            }
+        } else {
+            logger.warn("Attempt to add an undefined resource to a resource file.");
+        }
+    }
+};
+
+/**
+ * Return true if this resource file has been modified
+ * since it was loaded from disk.
+ *
+ * @returns {boolean} true if this resource file has been
+ * modified since it was loaded
+ */
+POFile.prototype.isDirty = function() {
+    return this.set.isDirty();
+};
 
 /**
  * Return the location on disk where the version of this file localized
@@ -586,20 +655,7 @@ POFile.prototype.localizeText = function(translations, locale) {
                         }
                     }
                 } else {
-                    // extract this value
-                    this.set.add(this.API.newResource({
-                        resType: "string",
-                        project: r.getProject(),
-                        key: key,
-                        sourceLocale: r.getSourceLocale(),
-                        source: text,
-                        pathName: r.getPath(),
-                        state: "new",
-                        comment: r.getComment(),
-                        datatype: r.getDataType(),
-                        context: r.getContext(),
-                        index: this.resourceIndex++
-                    }));
+                    translatedText = r.getTarget() || "";
                 }
 
                 output += 'msgstr "' + escapeQuotes(translatedText) + '"\n';
@@ -662,20 +718,7 @@ POFile.prototype.localizeText = function(translations, locale) {
                         }
                     }
                 } else {
-                    // extract this value
-                    this.set.add(this.API.newResource({
-                        resType: "plural",
-                        project: r.getProject(),
-                        key: key,
-                        sourceLocale: r.getSourceLocale(),
-                        sourceStrings: sourcePlurals,
-                        pathName: r.getPath(),
-                        state: "new",
-                        comment: r.getComment(),
-                        datatype: r.getDataType,
-                        context: r.getContext(),
-                        index: this.resourceIndex++
-                    }));
+                    translatedPlurals = r.getTargetPlurals() || {};
                 }
 
                 output += 'msgid_plural "' + escapeQuotes(sourcePlurals.other)  + '"\n';

--- a/POFile.js
+++ b/POFile.js
@@ -486,7 +486,7 @@ POFile.prototype.addResource = function(res) {
             // so that it can be a placeholder for the real translation later on
             this.set.add(this.API.newResource({
                 resType: res.getType(),
-                sourcePlurals: (res.getType() === "plural") ? res.getSourcePlurals() : undefined,
+                sourceStrings: (res.getType() === "plural") ? res.getSourcePlurals() : undefined,
                 source: (res.getType() === "string") ? res.getSource() : undefined,
                 sourceLocale: res.getSourceLocale(),
                 project: res.getProject(),

--- a/README.md
+++ b/README.md
@@ -196,6 +196,18 @@ file for more details.
 
 ## Release Notes
 
+### v1.1.0
+
+- Added the ability to use po files as output resource files by adding a write
+  method. This means it can also be used as an output format for the new
+  convert action.
+    - if resources are added where the target locale
+      does not match the locale of the PO file, then those resources
+      will be added as source-only resources
+    - handles resources with missing translations and puts a placeholder
+      entry into the PO file
+    - handles missing plural strings as well, depending on the language
+
 ### v1.0.1
 
 - Make this plugin able to read already-localized po files

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-po",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "main": "./POFileType.js",
     "description": "A loctool plugin that knows how to localize GNU po and pot files",
     "license": "Apache-2.0",

--- a/test/testPOFile.js
+++ b/test/testPOFile.js
@@ -2441,4 +2441,464 @@ module.exports.pofile = {
         test.done();
     },
 
+    testPOFileWriteSourceOnly: function(test) {
+        test.expect(5);
+
+        var base = path.dirname(module.id);
+
+        if (fs.existsSync(path.join(base, "testfiles/po/ru-RU.po"))) {
+            fs.unlinkSync(path.join(base, "testfiles/po/ru-RU.po"));
+        }
+
+        test.ok(!fs.existsSync(path.join(base, "testfiles/po/ru-RU.po")));
+
+        // custom project with no mappings should force it to use the default
+        // mappings to get the target locale
+        var p2 = new CustomProject({
+            name: "foo",
+            id: "foo",
+            sourceLocale: "en-US",
+            plugins: [
+                path.join(process.cwd(), "POFileType")
+            ]
+        }, "./test/testfiles", {
+            locales:["en-GB"],
+            targetDir: ".",
+        });
+        var t2 = new POFileType(p2);
+
+        var pof = new POFile({
+            project: p2,
+            pathName: "./po/ru-RU.po",
+            type: t2,
+            locale: "ru-RU"
+        });
+        test.ok(pof);
+
+
+        pof.addResource(new ContextResourceString({
+            project: "foo",
+            key: "string 1",
+            source: "string 1",
+            sourceLocale: "en-US",
+            datatype: "po"
+        }));
+        pof.addResource(new ContextResourceString({
+            project: "foo",
+            key: "string 2",
+            source: "string 2",
+            sourceLocale: "en-US",
+            datatype: "po"
+        }));
+        pof.addResource(new ResourcePlural({
+            project: "foo",
+            key: "one string",
+            sourceStrings: {
+                "one": "one string",
+                "other": "{$count} strings"
+            },
+            sourceLocale: "en-US",
+            datatype: "po"
+        }));
+        pof.addResource(new ContextResourceString({
+            project: "foo",
+            key: "string 3 and 4",
+            source: "string 3 and 4",
+            sourceLocale: "en-US",
+            datatype: "po"
+        }));
+
+        test.ok(!fs.existsSync(path.join(base, "testfiles/po/ru-RU.po")));
+
+        pof.write();
+
+        test.ok(fs.existsSync(path.join(base, "testfiles/po/ru-RU.po")));
+
+        content = fs.readFileSync(path.join(base, "testfiles/po/ru-RU.po"), "utf-8");
+
+        var expected =
+            'msgid ""\n' +
+            'msgstr ""\n' +
+            '"#-#-#-#-#  ./po/ru-RU.po  #-#-#-#-#\\n"\n' +
+            '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
+            '"Content-Transfer-Encoding: 8bit\\n"\n' +
+            '"Generated-By: loctool\\n"\n' +
+            '"Project-Id-Version: 1\\n"\n' +
+            '"Language: ru-RU\\n"\n' +
+            '"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\\n"\n' +
+            '\n' +
+            'msgid "string 1"\n' +
+            'msgstr ""\n' +
+            '\n' +
+            'msgid "string 2"\n' +
+            'msgstr ""\n' +
+            '\n' +
+            'msgid "one string"\n' +
+            'msgid_plural "{$count} strings"\n' +
+            'msgstr[0] ""\n' +
+            'msgstr[1] ""\n' +
+            'msgstr[2] ""\n' +
+            '\n' +
+            'msgid "string 3 and 4"\n' +
+            'msgstr ""\n\n';
+
+        diff(content, expected);
+        test.equal(content, expected);
+
+        test.done();
+    },
+
+    testPOFileWriteWithTranslation: function(test) {
+        test.expect(5);
+
+        var base = path.dirname(module.id);
+
+        if (fs.existsSync(path.join(base, "testfiles/po/ru-RU.po"))) {
+            fs.unlinkSync(path.join(base, "testfiles/po/ru-RU.po"));
+        }
+
+        test.ok(!fs.existsSync(path.join(base, "testfiles/po/ru-RU.po")));
+
+        // custom project with no mappings should force it to use the default
+        // mappings to get the target locale
+        var p2 = new CustomProject({
+            name: "foo",
+            id: "foo",
+            sourceLocale: "en-US",
+            plugins: [
+                path.join(process.cwd(), "POFileType")
+            ]
+        }, "./test/testfiles", {
+            locales:["en-GB"],
+            targetDir: ".",
+        });
+        var t2 = new POFileType(p2);
+
+        var pof = new POFile({
+            project: p2,
+            pathName: "./po/ru-RU.po",
+            type: t2,
+            locale: "ru-RU"
+        });
+        test.ok(pof);
+
+
+        pof.addResource(new ContextResourceString({
+            project: "foo",
+            key: "string 1",
+            source: "string 1",
+            sourceLocale: "en-US",
+            target: "строка 1",
+            targetLocale: "ru-RU",
+            datatype: "po"
+        }));
+        pof.addResource(new ContextResourceString({
+            project: "foo",
+            key: "string 2",
+            source: "string 2",
+            sourceLocale: "en-US",
+            target: "строка 2",
+            targetLocale: "ru-RU",
+            datatype: "po"
+        }));
+        pof.addResource(new ResourcePlural({
+            project: "foo",
+            key: "one string",
+            sourceStrings: {
+                "one": "one string",
+                "other": "{$count} strings"
+            },
+            sourceLocale: "en-US",
+            targetStrings: {
+                "one": "{$count} струна",
+                "few": "{$count} струны",
+                "other": "{$count} струн"
+            },
+            targetLocale: "ru-RU",
+            datatype: "po"
+        }));
+        pof.addResource(new ContextResourceString({
+            project: "foo",
+            key: "string 3 and 4",
+            source: "string 3 and 4",
+            sourceLocale: "en-US",
+            target: "строка 3 и 4",
+            targetLocale: "ru-RU",
+            datatype: "po"
+        }));
+
+        test.ok(!fs.existsSync(path.join(base, "testfiles/po/ru-RU.po")));
+
+        pof.write();
+
+        test.ok(fs.existsSync(path.join(base, "testfiles/po/ru-RU.po")));
+
+        content = fs.readFileSync(path.join(base, "testfiles/po/ru-RU.po"), "utf-8");
+
+        var expected =
+            'msgid ""\n' +
+            'msgstr ""\n' +
+            '"#-#-#-#-#  ./po/ru-RU.po  #-#-#-#-#\\n"\n' +
+            '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
+            '"Content-Transfer-Encoding: 8bit\\n"\n' +
+            '"Generated-By: loctool\\n"\n' +
+            '"Project-Id-Version: 1\\n"\n' +
+            '"Language: ru-RU\\n"\n' +
+            '"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\\n"\n' +
+            '\n' +
+            'msgid "string 1"\n' +
+            'msgstr "строка 1"\n' +
+            '\n' +
+            'msgid "string 2"\n' +
+            'msgstr "строка 2"\n' +
+            '\n' +
+            'msgid "one string"\n' +
+            'msgid_plural "{$count} strings"\n' +
+            'msgstr[0] "{$count} струна"\n' +
+            'msgstr[1] "{$count} струны"\n' +
+            'msgstr[2] "{$count} струн"\n' +
+            '\n' +
+            'msgid "string 3 and 4"\n' +
+            'msgstr "строка 3 и 4"\n\n';
+
+        diff(content, expected);
+        test.equal(content, expected);
+
+        test.done();
+    },
+
+    testPOFileWriteWithMissingTranslations: function(test) {
+        test.expect(5);
+
+        var base = path.dirname(module.id);
+
+        if (fs.existsSync(path.join(base, "testfiles/po/ru-RU.po"))) {
+            fs.unlinkSync(path.join(base, "testfiles/po/ru-RU.po"));
+        }
+
+        test.ok(!fs.existsSync(path.join(base, "testfiles/po/ru-RU.po")));
+
+        // custom project with no mappings should force it to use the default
+        // mappings to get the target locale
+        var p2 = new CustomProject({
+            name: "foo",
+            id: "foo",
+            sourceLocale: "en-US",
+            plugins: [
+                path.join(process.cwd(), "POFileType")
+            ]
+        }, "./test/testfiles", {
+            locales:["en-GB"],
+            targetDir: ".",
+        });
+        var t2 = new POFileType(p2);
+
+        var pof = new POFile({
+            project: p2,
+            pathName: "./po/ru-RU.po",
+            type: t2,
+            locale: "ru-RU"
+        });
+        test.ok(pof);
+
+
+        pof.addResource(new ContextResourceString({
+            project: "foo",
+            key: "string 1",
+            source: "string 1",
+            sourceLocale: "en-US",
+            target: "строка 1",
+            targetLocale: "ru-RU",
+            datatype: "po"
+        }));
+        pof.addResource(new ContextResourceString({
+            project: "foo",
+            key: "string 2",
+            source: "string 2",
+            sourceLocale: "en-US",
+            targetLocale: "ru-RU",
+            datatype: "po"
+        }));
+        pof.addResource(new ResourcePlural({
+            project: "foo",
+            key: "one string",
+            sourceStrings: {
+                "one": "one string",
+                "other": "{$count} strings"
+            },
+            sourceLocale: "en-US",
+            targetStrings: {
+                "one": "{$count} струна",
+                "other": "{$count} струн"
+            },
+            targetLocale: "ru-RU",
+            datatype: "po"
+        }));
+        pof.addResource(new ContextResourceString({
+            project: "foo",
+            key: "string 3 and 4",
+            source: "string 3 and 4",
+            sourceLocale: "en-US",
+            targetLocale: "ru-RU",
+            datatype: "po"
+        }));
+
+        test.ok(!fs.existsSync(path.join(base, "testfiles/po/ru-RU.po")));
+
+        pof.write();
+
+        test.ok(fs.existsSync(path.join(base, "testfiles/po/ru-RU.po")));
+
+        content = fs.readFileSync(path.join(base, "testfiles/po/ru-RU.po"), "utf-8");
+
+        var expected =
+            'msgid ""\n' +
+            'msgstr ""\n' +
+            '"#-#-#-#-#  ./po/ru-RU.po  #-#-#-#-#\\n"\n' +
+            '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
+            '"Content-Transfer-Encoding: 8bit\\n"\n' +
+            '"Generated-By: loctool\\n"\n' +
+            '"Project-Id-Version: 1\\n"\n' +
+            '"Language: ru-RU\\n"\n' +
+            '"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\\n"\n' +
+            '\n' +
+            'msgid "string 1"\n' +
+            'msgstr "строка 1"\n' +
+            '\n' +
+            'msgid "string 2"\n' +
+            'msgstr ""\n' +
+            '\n' +
+            'msgid "one string"\n' +
+            'msgid_plural "{$count} strings"\n' +
+            'msgstr[0] "{$count} струна"\n' +
+            'msgstr[1] ""\n' +
+            'msgstr[2] "{$count} струн"\n' +
+            '\n' +
+            'msgid "string 3 and 4"\n' +
+            'msgstr ""\n\n';
+
+        diff(content, expected);
+        test.equal(content, expected);
+
+        test.done();
+    },
+
+    testPOFileWriteWrongTargetLocale: function(test) {
+        test.expect(5);
+
+        var base = path.dirname(module.id);
+
+        if (fs.existsSync(path.join(base, "testfiles/po/de-DE.po"))) {
+            fs.unlinkSync(path.join(base, "testfiles/po/de-DE.po"));
+        }
+
+        test.ok(!fs.existsSync(path.join(base, "testfiles/po/de-DE.po")));
+
+        // custom project with no mappings should force it to use the default
+        // mappings to get the target locale
+        var p2 = new CustomProject({
+            name: "foo",
+            id: "foo",
+            sourceLocale: "en-US",
+            plugins: [
+                path.join(process.cwd(), "POFileType")
+            ]
+        }, "./test/testfiles", {
+            locales:["en-GB"],
+            targetDir: ".",
+        });
+        var t2 = new POFileType(p2);
+
+        var pof = new POFile({
+            project: p2,
+            pathName: "./po/de-DE.po",
+            type: t2,
+            locale: "de-DE"
+        });
+        test.ok(pof);
+
+        // should add these as source-only resources
+        pof.addResource(new ContextResourceString({
+            project: "foo",
+            key: "string 1",
+            source: "string 1",
+            sourceLocale: "en-US",
+            target: "строка 1",
+            targetLocale: "ru-RU",
+            datatype: "po"
+        }));
+        pof.addResource(new ContextResourceString({
+            project: "foo",
+            key: "string 2",
+            source: "string 2",
+            sourceLocale: "en-US",
+            target: "строка 2",
+            targetLocale: "ru-RU",
+            datatype: "po"
+        }));
+        pof.addResource(new ResourcePlural({
+            project: "foo",
+            key: "one string",
+            sourceStrings: {
+                "one": "one string",
+                "other": "{$count} strings"
+            },
+            sourceLocale: "en-US",
+            targetStrings: {
+                "one": "{$count} струна",
+                "few": "{$count} струны",
+                "other": "{$count} струн"
+            },
+            targetLocale: "ru-RU",
+            datatype: "po"
+        }));
+        pof.addResource(new ContextResourceString({
+            project: "foo",
+            key: "string 3 and 4",
+            source: "string 3 and 4",
+            sourceLocale: "en-US",
+            target: "строка 3 и 4",
+            targetLocale: "ru-RU",
+            datatype: "po"
+        }));
+
+        test.ok(!fs.existsSync(path.join(base, "testfiles/po/de-DE.po")));
+
+        pof.write();
+
+        test.ok(fs.existsSync(path.join(base, "testfiles/po/de-DE.po")));
+
+        content = fs.readFileSync(path.join(base, "testfiles/po/de-DE.po"), "utf-8");
+
+        var expected =
+            'msgid ""\n' +
+            'msgstr ""\n' +
+            '"#-#-#-#-#  ./po/de-DE.po  #-#-#-#-#\\n"\n' +
+            '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
+            '"Content-Transfer-Encoding: 8bit\\n"\n' +
+            '"Generated-By: loctool\\n"\n' +
+            '"Project-Id-Version: 1\\n"\n' +
+            '"Language: de-DE\\n"\n' +
+            '"Plural-Forms: nplurals=2; plural=n != 1;\\n"\n' +
+            '\n' +
+            'msgid "string 1"\n' +
+            'msgstr ""\n' +
+            '\n' +
+            'msgid "string 2"\n' +
+            'msgstr ""\n' +
+            '\n' +
+            'msgid "one string"\n' +
+            'msgid_plural "{$count} strings"\n' +
+            'msgstr[0] ""\n' +
+            'msgstr[1] ""\n' +
+            '\n' +
+            'msgid "string 3 and 4"\n' +
+            'msgstr ""\n\n';
+
+        diff(content, expected);
+        test.equal(content, expected);
+
+        test.done();
+    },
+
 };


### PR DESCRIPTION
- Added the ability to use po files as output resource files by adding a write method. This means it can also be used as an output format for the new convert action.
- if resources are added where the target locale does not match the locale of the PO file, then those resources will be added as source-only resources
- handles resources with missing translations and puts a placeholder entry into the PO file
- handles missing plural strings as well, depending on the language