### PR TITLE
The path for each resource should be a file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ file for more details.
 
 ## Release Notes
 
+### v1.1.1
+
+- fixed a bug where every resource from the PO file had its own file tag
+  in the xliff output because the "original" path was set to the file
+  name colon line number.
+
 ### v1.1.0
 
 - Added the ability to use po files as output resource files by adding a write

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-po",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "main": "./POFileType.js",
     "description": "A loctool plugin that knows how to localize GNU po and pot files",
     "license": "Apache-2.0",

--- a/test/testPOFile.js
+++ b/test/testPOFile.js
@@ -761,7 +761,7 @@ module.exports.pofile = {
 
         pof.parse(
             '# translator\'s comments\n' +
-            '#: src/foo.html:32\n' +
+            '#: src/foo.html:32 src/bar.html:234\n' +
             '#. This is comments from the engineer to the translator for string 1.\n' +
             '#, c-format\n' +
             '#| str 1\n' +
@@ -769,7 +769,7 @@ module.exports.pofile = {
             'msgstr ""\n' +
             '\n' +
             '# translator\'s comments 2\n' +
-            '#: src/bar.html:644\n' +
+            '#: src/bar.html:644 src/asdf.html:232\n' +
             '#. This is comments from the engineer to the translator for string 2.\n' +
             '#, javascript-format,gcc-internal-format\n' +
             '#| str 2\n' +
@@ -788,19 +788,21 @@ module.exports.pofile = {
         test.equal(resources[0].getKey(), "string 1");
         test.equal(resources[0].getComment(),
             '{"translator":["translator\'s comments"],' +
+             '"paths":["src/foo.html:32 src/bar.html:234"],' +
              '"extracted":["This is comments from the engineer to the translator for string 1."],' +
              '"flags":["c-format"],' +
              '"previous":["str 1"]}');
-        test.equal(resources[0].getPath(), "src/foo.html:32");
+        test.equal(resources[0].getPath(), "src/foo.html");
 
         test.equal(resources[1].getSource(), "string 2");
         test.equal(resources[1].getKey(), "string 2");
         test.equal(resources[1].getComment(),
             '{"translator":["translator\'s comments 2"],' +
+             '"paths":["src/bar.html:644 src/asdf.html:232"],' +
              '"extracted":["This is comments from the engineer to the translator for string 2."],' +
              '"flags":["javascript-format,gcc-internal-format"],' +
              '"previous":["str 2"]}');
-        test.equal(resources[1].getPath(), "src/bar.html:644");
+        test.equal(resources[1].getPath(), "src/bar.html");
 
         test.done();
     },
@@ -838,10 +840,11 @@ module.exports.pofile = {
         test.equal(resources[0].getKey(), "string 1");
         test.equal(resources[0].getComment(),
             '{"translator":["translator\'s comments"],' +
+             '"paths":["src/foo.html:32"],' +
              '"extracted":["This is comments from the engineer to the translator for string 1."],' +
              '"flags":["c-format"],' +
              '"previous":["str 1"]}');
-        test.equal(resources[0].getPath(), "src/foo.html:32");
+        test.equal(resources[0].getPath(), "src/foo.html");
 
         // comments for string 1 should not carry over to string 2
         test.equal(resources[1].getSource(), "string 2");
@@ -881,8 +884,8 @@ module.exports.pofile = {
 
         test.equal(resources[0].getSource(), "string 1");
         test.equal(resources[0].getKey(), "string 1");
-        test.ok(!resources[0].getComment());
-        test.equal(resources[0].getPath(), "src/foo.html:32 src/bar.html:32 src/asdf.html:32 src/xyz.html:32 src/abc.html:32");
+        test.equal(resources[0].getComment(), '{"paths":["src/foo.html:32","src/bar.html:32","src/asdf.html:32","src/xyz.html:32","src/abc.html:32"]}');
+        test.equal(resources[0].getPath(), "src/foo.html");
 
         test.done();
     },
@@ -1265,7 +1268,8 @@ module.exports.pofile = {
             '# note for translators 2\n' +
             '#. extracted comment 1\n' +
             '#. extracted comment 2\n' +
-            '#: src/a/b/c.js:32 src/a/b/x.js:32\n' +
+            '#: src/a/b/c.js:32\n' +
+            '#: src/a/b/x.js:32\n' +
             '#, c-format\n' +
             '#, javascript-format\n' +
             '#| str2\n' +


### PR DESCRIPTION
... not a list of files with line numbers. If we do that, then xliff files will have a different file tag for each line number
in a source file. The work-around is to take the first file named and make that the "original" path in the resource and
keep track of the rest of the paths in the comments field.

Old xliff sample:
```
<file original="foo/bar.vue:32" ... >
   <body>
     <trans-unit>
        resource from line 32
     </trans-unit>
  </body>
</file>
<file original="foo/bar.vue:34" ... >
   <body>
     <trans-unit>
        resource from line 34
     </trans-unit>
  </body>
</file>
```

Now we the xliff output is:
```
<file original="foo/bar.vue" ... >
   <body>
     <trans-unit>
        resource from line 32
     </trans-unit>
     <trans-unit>
        resource from line 34
     </trans-unit>
  </body>
</file>
```
