### PR TITLE
Fix extraction of path names without line numbers

### DIFF
--- a/POFile.js
+++ b/POFile.js
@@ -208,7 +208,7 @@ var commentTypeMap = {
     ':': "paths"
 };
 
-var rePathStrip = /^: *([^ ]+)(:\d+)/;
+var rePathStrip = /^: *(([^: ]|:[^\d])+)(:\d+)?/;
 
 /**
  * Parse the data string looking for the localizable strings and add them to the

--- a/README.md
+++ b/README.md
@@ -196,6 +196,11 @@ file for more details.
 
 ## Release Notes
 
+### v1.1.2
+
+- fixed a bug where path names in #: comments that did not have a
+  colon and a line number were not being extracted properly
+
 ### v1.1.1
 
 - fixed a bug where every resource from the PO file had its own file tag

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-po",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "main": "./POFileType.js",
     "description": "A loctool plugin that knows how to localize GNU po and pot files",
     "license": "Apache-2.0",

--- a/test/testPOFile.js
+++ b/test/testPOFile.js
@@ -807,6 +807,47 @@ module.exports.pofile = {
         test.done();
     },
 
+    testPOFileParseExtractFileNameNoLineNumbers: function(test) {
+        test.expect(12);
+
+        var pof = new POFile({
+            project: p,
+            type: t
+        });
+        test.ok(pof);
+
+        pof.parse(
+            '#: src/foo.html src/bar.html\n' +
+            'msgid "string 1"\n' +
+            'msgstr ""\n' +
+            '\n' +
+            '#: src/bar.html\n' +
+            'msgid "string 2"\n' +
+            'msgstr ""\n'
+        );
+
+        var set = pof.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 2);
+        var resources = set.getAll();
+        test.equal(resources.length, 2);
+
+        test.equal(resources[0].getSource(), "string 1");
+        test.equal(resources[0].getKey(), "string 1");
+        test.equal(resources[0].getComment(),
+            '{"paths":["src/foo.html src/bar.html"]}');
+        test.equal(resources[0].getPath(), "src/foo.html");
+
+        test.equal(resources[1].getSource(), "string 2");
+        test.equal(resources[1].getKey(), "string 2");
+        test.equal(resources[1].getComment(),
+            '{"paths":["src/bar.html"]}');
+        test.equal(resources[1].getPath(), "src/bar.html");
+
+        test.done();
+    },
+
     testPOFileParseClearComments: function(test) {
         test.expect(12);
 


### PR DESCRIPTION
Path names in #: comments which did not have a line number attached
to them were being extracted incorrectly. Now it works properly with
or without line numbers.