### PR TITLE
Make sure to output empty string if source == target

### DIFF
--- a/POFile.js
+++ b/POFile.js
@@ -659,6 +659,11 @@ POFile.prototype.localizeText = function(translations, locale) {
                     translatedText = r.getTarget() || "";
                 }
 
+                if (translatedText === r.getSource()) {
+                    // put nothing if there is no difference in the translation
+                    translatedText = "";
+                }
+
                 output += 'msgstr "' + escapeQuotes(translatedText) + '"\n';
             } else {
                 // plural string
@@ -670,9 +675,9 @@ POFile.prototype.localizeText = function(translations, locale) {
                     var translatedPlurals = {};
                     pluralCategories.forEach(function(category) {
                         if (category === "one") {
-                            translatedPlurals.one = sourcePlurals.one;
+                            translatedPlurals.one = "";
                         } else {
-                            translatedPlurals[category] = sourcePlurals.other;
+                            translatedPlurals[category] = "";
                         }
                     });
                     if ((locale !== this.project.pseudoLocale || !this.project.settings.nopseudo) &&
@@ -725,7 +730,9 @@ POFile.prototype.localizeText = function(translations, locale) {
                 output += 'msgid_plural "' + escapeQuotes(sourcePlurals.other)  + '"\n';
                 if (translatedPlurals) {
                     for (var j = 0; j < pluralCategories.length; j++) {
-                        output += 'msgstr[' + j + '] "' + escapeQuotes(translatedPlurals[pluralCategories[j]]) + '"\n';
+                        var translation = translatedPlurals[pluralCategories[j]] !== sourcePlurals[pluralCategories[j]] ?
+                            translatedPlurals[pluralCategories[j]] : "";
+                        output += 'msgstr[' + j + '] "' + escapeQuotes(translation) + '"\n';
                     }
                 }
             }

--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ file for more details.
 
 ## Release Notes
 
+### v1.2.1
+
+- Make sure to output an empty string if the translated string is the
+  same as the source string so that `gettext()` will default back to
+  the source string
+
 ### v1.2.0
 
 - added the ability to specify a locale map so that output file names of

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-po",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "main": "./POFileType.js",
     "description": "A loctool plugin that knows how to localize GNU po and pot files",
     "license": "Apache-2.0",

--- a/test/testPOFile.js
+++ b/test/testPOFile.js
@@ -1436,6 +1436,205 @@ module.exports.pofile = {
         test.done();
     },
 
+    testPOFileLocalizeTextWithNoActualTranslation: function(test) {
+        test.expect(2);
+
+        var pof = new POFile({
+            project: p,
+            pathName: "./po/messages.po",
+            type: t
+        });
+        test.ok(pof);
+
+        pof.parse(
+            'msgid "string 1"\n' +
+            'msgstr ""\n' +
+            '\n' +
+            'msgid "string 2"\n' +
+            'msgstr ""\n'
+        );
+
+        var translations = new TranslationSet();
+        translations.add(new ContextResourceString({
+            project: "foo",
+            key: "string 1",
+            source: "string 1",
+            sourceLocale: "en-US",
+            target: "string 1",
+            targetLocale: "fr-FR",
+            datatype: "po"
+        }));
+        translations.add(new ContextResourceString({
+            project: "foo",
+            key: "string 2",
+            source: "string 2",
+            sourceLocale: "en-US",
+            target: "string 2",
+            targetLocale: "fr-FR",
+            datatype: "po"
+        }));
+
+        var actual = pof.localizeText(translations, "fr-FR");
+        var expected =
+            'msgid ""\n' +
+            'msgstr ""\n' +
+            '"#-#-#-#-#  ./po/messages.po  #-#-#-#-#\\n"\n' +
+            '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
+            '"Content-Transfer-Encoding: 8bit\\n"\n' +
+            '"Generated-By: loctool\\n"\n' +
+            '"Project-Id-Version: 1\\n"\n' +
+            '"Language: fr-FR\\n"\n' +
+            '"Plural-Forms: nplurals=2; plural=n>1;\\n"\n' +
+            '\n' +
+            'msgid "string 1"\n' +
+            'msgstr ""\n' +
+            '\n' +
+            'msgid "string 2"\n' +
+            'msgstr ""\n\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testPOFileLocalizeTextWithExistingTranslations: function(test) {
+        test.expect(2);
+
+        var pof = new POFile({
+            project: p,
+            pathName: "./po/messages.po",
+            type: t
+        });
+        test.ok(pof);
+
+        pof.parse(
+            'msgid "string 1"\n' +
+            'msgstr "string 1"\n' +
+            '\n' +
+            'msgid "string 2"\n' +
+            'msgstr "string 2"\n'
+        );
+
+        var translations = new TranslationSet();
+        translations.add(new ContextResourceString({
+            project: "foo",
+            key: "string 1",
+            source: "string 1",
+            sourceLocale: "en-US",
+            target: "string 1",
+            targetLocale: "fr-FR",
+            datatype: "po"
+        }));
+        translations.add(new ContextResourceString({
+            project: "foo",
+            key: "string 2",
+            source: "string 2",
+            sourceLocale: "en-US",
+            target: "string 2",
+            targetLocale: "fr-FR",
+            datatype: "po"
+        }));
+
+        var actual = pof.localizeText(translations, "fr-FR");
+        var expected =
+            'msgid ""\n' +
+            'msgstr ""\n' +
+            '"#-#-#-#-#  ./po/messages.po  #-#-#-#-#\\n"\n' +
+            '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
+            '"Content-Transfer-Encoding: 8bit\\n"\n' +
+            '"Generated-By: loctool\\n"\n' +
+            '"Project-Id-Version: 1\\n"\n' +
+            '"Language: fr-FR\\n"\n' +
+            '"Plural-Forms: nplurals=2; plural=n>1;\\n"\n' +
+            '\n' +
+            'msgid "string 1"\n' +
+            'msgstr ""\n' +
+            '\n' +
+            'msgid "string 2"\n' +
+            'msgstr ""\n\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testPOFileLocalizeTextPluralsWithNoActualTranslation: function(test) {
+        test.expect(2);
+
+        var pof = new POFile({
+            project: p,
+            pathName: "./po/messages.po",
+            type: t
+        });
+        test.ok(pof);
+
+        pof.parse(
+            'msgid "{$count} object"\n' +
+            'msgid_plural "{$count} objects"\n' +
+            '\n' +
+            'msgid "{$count} item"\n' +
+            'msgid_plural "{$count} items"\n'
+        );
+
+        var translations = new TranslationSet();
+        translations.add(new ResourcePlural({
+            project: "foo",
+            key: "{$count} object",
+            sourceStrings: {
+                one: "{$count} object",
+                other: "{$count} objects"
+            },
+            sourceLocale: "en-US",
+            targetStrings: {
+                one: "{$count} object",
+                other: "{$count} objects"
+            },
+            targetLocale: "fr-FR",
+            datatype: "po"
+        }));
+        translations.add(new ResourcePlural({
+            project: "foo",
+            key: "{$count} item",
+            sourceStrings: {
+                one: "{$count} item",
+                other: "{$count} items"
+            },
+            sourceLocale: "en-US",
+            targetStrings: {
+                one: "{$count} item",
+                other: "{$count} items"
+            },
+            targetLocale: "fr-FR",
+            datatype: "po"
+        }));
+
+        var actual = pof.localizeText(translations, "fr-FR");
+        var expected =
+            'msgid ""\n' +
+            'msgstr ""\n' +
+            '"#-#-#-#-#  ./po/messages.po  #-#-#-#-#\\n"\n' +
+            '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
+            '"Content-Transfer-Encoding: 8bit\\n"\n' +
+            '"Generated-By: loctool\\n"\n' +
+            '"Project-Id-Version: 1\\n"\n' +
+            '"Language: fr-FR\\n"\n' +
+            '"Plural-Forms: nplurals=2; plural=n>1;\\n"\n' +
+            '\n' +
+            'msgid "{$count} object"\n' +
+            'msgid_plural "{$count} objects"\n' +
+            'msgstr[0] ""\n' +
+            'msgstr[1] ""\n' +
+            '\n' +
+            'msgid "{$count} item"\n' +
+            'msgid_plural "{$count} items"\n' +
+            'msgstr[0] ""\n' +
+            'msgstr[1] ""\n\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
     testPOFileLocalize: function(test) {
         test.expect(7);
 


### PR DESCRIPTION
Previously, we would just put the target string into the localized po file as-is. But, many localization tools will leave out the contents of the target string if it is the same as the source string. This saves space.
