### PR TITLE
Better target locale handling

### DIFF
--- a/POFile.js
+++ b/POFile.js
@@ -290,7 +290,7 @@ POFile.prototype.parse = function(data) {
                                     datatype: this.type.datatype,
                                     context: context,
                                     index: this.resourceIndex++,
-                                    targetLocale: this.localeSpec && this.localeSpec !== this.project.sourceLocale ? this.localeSpec : undefined
+                                    targetLocale: translationPlurals && this.localeSpec && this.localeSpec !== this.project.sourceLocale ? this.localeSpec : undefined
                                 };
                                 if (translationPlurals) {
                                     options.targetStrings = translationPlurals;
@@ -308,7 +308,7 @@ POFile.prototype.parse = function(data) {
                                     datatype: this.type.datatype,
                                     context: context,
                                     index: this.resourceIndex++,
-                                    targetLocale: this.localeSpec && this.localeSpec !== this.project.sourceLocale ? this.localeSpec : undefined
+                                    targetLocale: translation && this.localeSpec && this.localeSpec !== this.project.sourceLocale ? this.localeSpec : undefined
                                 };
                                 if (translation) {
                                     options.target = translation;

--- a/POFileType.js
+++ b/POFileType.js
@@ -350,7 +350,7 @@ POFileType.prototype.newFile = function(path, options) {
         project: this.project,
         pathName: path,
         type: this,
-	locale: options.targetLocale
+        locale: options && options.targetLocale
     });
 };
 

--- a/POFileType.js
+++ b/POFileType.js
@@ -345,11 +345,12 @@ POFileType.prototype.write = function() {
     // write out the resources
 };
 
-POFileType.prototype.newFile = function(path) {
+POFileType.prototype.newFile = function(path, options) {
     return new POFile({
         project: this.project,
         pathName: path,
-        type: this
+        type: this,
+	locale: options.targetLocale
     });
 };
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ file for more details.
 
 - Fix a bug where the target locale was not used when specified to
   POFileType.newFile. It was never passed in to the POFile constructor.
+- Fix a bug where the target locale was specified for string and
+  plural resources and there were no target strings or plurals. Having
+  the locale but no target confuses mojito.
 
 ### v1.2.1
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,11 @@ file for more details.
 
 ## Release Notes
 
+### v1.2.2
+
+- Fix a bug where the target locale was not used when specified to
+  POFileType.newFile. It was never passed in to the POFile constructor.
+
 ### v1.2.1
 
 - Make sure to output an empty string if the translated string is the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-po",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "main": "./POFileType.js",
     "description": "A loctool plugin that knows how to localize GNU po and pot files",
     "license": "Apache-2.0",

--- a/test/testPOFile.js
+++ b/test/testPOFile.js
@@ -408,7 +408,7 @@ module.exports.pofile = {
         test.equal(resources[0].getKey(), "one object");
         test.equal(resources[0].getSourceLocale(), "en-US");
         test.ok(!resources[0].getTargetPlurals());
-        test.equal(resources[0].getTargetLocale(), "de-DE");
+        test.ok(!resources[0].getTargetLocale());
 
         test.done();
     },


### PR DESCRIPTION
Two fixes:

- Don't set the target locale into resources that do not have a target string or plural. This confuses mojito. Instead, they will be source-only resources.
- Pass the target locale in `POFileType.newFile` to the new `POFile` instance in case the target locale is specified on the command-line. Otherwise, it will do the normal method of finding the target locale. (That is, use the mapping templates to figure out which part of the path is the locale.)