### PR TITLE
Add support for locale mappings in each file name template mapping

### DIFF
--- a/POFile.js
+++ b/POFile.js
@@ -531,7 +531,7 @@ POFile.prototype.isDirty = function() {
  * @returns {String} the localized path name
  */
 POFile.prototype.getLocalizedPath = function(locale) {
-    return this.type.getLocalizedPath(this.mapping.template, this.pathName, locale);
+    return this.type.getLocalizedPath(this.mapping, this.pathName, locale);
 };
 
 /**

--- a/POFileType.js
+++ b/POFileType.js
@@ -270,14 +270,15 @@ POFileType.prototype.getLocaleFromPath = function(template, pathname) {
 /**
  * Return the location on disk where the version of this file localized
  * for the given locale should be written.
- * @param {String} template template for the output file
+ * @param {Object} mapping the mapping for this source file
  * @param {String} pathname path to the source file
  * @param {String} locale the locale spec for the target locale
  * @returns {String} the localized path name
  */
-POFileType.prototype.getLocalizedPath = function(template, pathname, locale) {
+POFileType.prototype.getLocalizedPath = function(mapping, pathname, locale) {
     var output = "";
-    var l = new Locale(this.project.getOutputLocale(locale));
+    var template = mapping && mapping.template;
+    var l = new Locale((mapping && mapping.localeMap && mapping.localeMap[locale]) || this.project.getOutputLocale(locale));
 
     if (!template) {
         template = defaultMappings["**/*.po"].template;

--- a/README.md
+++ b/README.md
@@ -154,6 +154,15 @@ used within the po property:
         - [localeUnder] the full BCP-47 locale specification, but using
           underscores to separate the locale parts instead of dashes.
           eg. "zh-Hans-CN" -> "zh_Hans_CN"
+    - localeMap: an output locale map that maps the locale used in the
+      translations to a different locale for use in the file name template.
+      For example, an app may wish to use the locale specifier "zh-CN"
+      instead of the full "zh-Hans-CN" for some output files, but not
+      all of them. In this case, a locale map for this template mapping
+      is how this can be achieved. Any locale not listed in the mapping
+      will be used as-is. The overall [shared] locale map is also applied
+      if there is no locale map in the template mapping for a particular
+      locale.
 
 
 Example configuration:
@@ -167,7 +176,12 @@ Example configuration:
                     "template": "resources/[locale].po"
                 },
                 "sublibrary/**/library.pot": {
-                    "template": "[dir]/[locale].po"
+                    "template": "[dir]/[locale].po",
+                    "localeMap": {
+                        "nb-NO": "no",
+                        "sr-Cyrl-RS": "sr-RS",
+                        "zh-Hans-CN": "zh-CN"
+                    }
                 }
             }
         }
@@ -182,7 +196,9 @@ the output is sent to a file named after the target locale located in the
 In the second part of the example, any `library.pot` file that appears in
 the `sublibrary` directory will be localized and the results sent to a
 po file named after each target locale which will appear in the same
-directory where the source file was located.
+directory where the source file was located. If the locale is one of the
+ones listed in the locale map, it will be mapped before being substituted
+in to the template.
 
 If the name of the localized file that the template produces is the same as
 the source file name, this plugin will throw an exception, the file will not
@@ -195,6 +211,14 @@ This plugin is license under Apache2. See the [LICENSE](./LICENSE)
 file for more details.
 
 ## Release Notes
+
+### v1.3.0
+
+- Added the ability to specify a locale map in the file name template
+  mapping. This allows for different locale specifications for different
+  sets of output files, which may be necessary if those output files
+  are intended to be used in different programming languages or on
+  different platforms that support a different set of locales.
 
 ### v1.2.2
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-po",
-    "version": "1.2.2",
+    "version": "1.3.0",
     "main": "./POFileType.js",
     "description": "A loctool plugin that knows how to localize GNU po and pot files",
     "license": "Apache-2.0",

--- a/test/testPOFile.js
+++ b/test/testPOFile.js
@@ -55,6 +55,9 @@ var p = new CustomProject({
     locales:["en-GB"],
     targetDir: ".",
     nopseudo: true,
+    localeMap: {
+        "nb-NO": "nb"
+    },
     po: {
         mappings: {
             "**/messages.po": {
@@ -67,7 +70,12 @@ var p = new CustomProject({
                 "template": "[dir]/[locale].po"
             },
             "**/*.po": {
-                "template": "[dir]/[locale].po"
+                "template": "[dir]/[locale].po",
+                localeMap: {
+                    "nb-NO": "no",
+                    "zh-Hant-TW": "zh-Hant",
+                    "zh-Hant-HK": "zh-HK"
+                }
             }
         }
     }
@@ -2002,6 +2010,68 @@ module.exports.pofile = {
 
         test.ok(fs.existsSync(path.join(base, "testfiles/resources/template_fr-FR.po")));
         test.ok(fs.existsSync(path.join(base, "testfiles/resources/template_de-DE.po")));
+
+        test.done();
+    },
+
+    testPOFileLocalizeWithAlternateLocaleMapping: function(test) {
+        test.expect(3);
+
+        var base = path.dirname(module.id);
+
+        if (fs.existsSync(path.join(base, "./testfiles/po/no.po"))) {
+            fs.unlinkSync(path.join(base, "./testfiles/po/no.po"));
+        }
+
+        test.ok(!fs.existsSync(path.join(base, "./testfiles/po/no.po")));
+
+        var pof = new POFile({
+            project: p,
+            pathName: "./po/foo.po",
+            type: t
+        });
+        test.ok(pof);
+
+        // should read the file
+        pof.extract();
+
+        var translations = new TranslationSet();
+
+        // should use the locale map in the mapping rather than the shared one
+        pof.localize(translations, ["nb-NO"]);
+
+        test.ok(fs.existsSync(path.join(base, "./testfiles/po/no.po")));
+
+        test.done();
+    },
+
+    testPOFileLocalizeWithSharedLocaleMapping: function(test) {
+        test.expect(3);
+
+        var base = path.dirname(module.id);
+
+        if (fs.existsSync(path.join(base, "testfiles/resources/template_nb.po"))) {
+            fs.unlinkSync(path.join(base, "testfiles/resources/template_nb.po"));
+        }
+
+        test.ok(!fs.existsSync(path.join(base, "testfiles/resources/template_nb.po")));
+
+        var pof = new POFile({
+            project: p,
+            pathName: "./po/template.po",
+            type: t
+        });
+        test.ok(pof);
+
+        // should read the file
+        pof.extract();
+
+        var translations = new TranslationSet();
+
+        // should use the shared locale map because there isn't one in the mapping
+        pof.localize(translations, ["nb-NO"]);
+
+        test.ok(fs.existsSync(path.join(base, "testfiles/resources/template_nb.po")));
 
         test.done();
     },

--- a/test/testPOFileType.js
+++ b/test/testPOFileType.js
@@ -86,7 +86,7 @@ module.exports.pofiletype = {
         var jft = new POFileType(p);
         test.ok(jft);
 
-        test.equals(jft.getLocalizedPath('resources/[localeDir]/strings.po', "x/y/strings.po", "de-DE"), "resources/de/DE/strings.po");
+        test.equals(jft.getLocalizedPath({template:'resources/[localeDir]/strings.po'}, "x/y/strings.po", "de-DE"), "resources/de/DE/strings.po");
 
         test.done();
     },
@@ -97,7 +97,23 @@ module.exports.pofiletype = {
         var jft = new POFileType(p);
         test.ok(jft);
 
-        test.equals(jft.getLocalizedPath('[dir]/[localeDir]/strings.po', "x/y/strings.po", "de-DE"), "x/y/de/DE/strings.po");
+        test.equals(jft.getLocalizedPath({template:'[dir]/[localeDir]/strings.po'}, "x/y/strings.po", "de-DE"), "x/y/de/DE/strings.po");
+
+        test.done();
+    },
+
+    testPOFileTypeGetLocalizedPathDirWithLocaleMap: function(test) {
+        test.expect(2);
+
+        var jft = new POFileType(p);
+        test.ok(jft);
+
+        test.equals(jft.getLocalizedPath({
+            template:'[dir]/[localeDir]/strings.po',
+            localeMap: {
+                "de-DE": "de"
+            }
+        }, "x/y/strings.po", "de-DE"), "x/y/de/strings.po");
 
         test.done();
     },
@@ -108,7 +124,7 @@ module.exports.pofiletype = {
         var jft = new POFileType(p2);
         test.ok(jft);
 
-        test.equals(jft.getLocalizedPath('[dir]/[localeDir]/strings.po', "x/y/strings.po", "de-DE"), "x/y/de/strings.po");
+        test.equals(jft.getLocalizedPath({template:'[dir]/[localeDir]/strings.po'}, "x/y/strings.po", "de-DE"), "x/y/de/strings.po");
 
         test.done();
     },
@@ -119,7 +135,7 @@ module.exports.pofiletype = {
         var jft = new POFileType(p);
         test.ok(jft);
 
-        test.equals(jft.getLocalizedPath('[localeDir]/tr-[basename].j', "x/y/strings.po", "de-DE"), "de/DE/tr-strings.j");
+        test.equals(jft.getLocalizedPath({template:'[localeDir]/tr-[basename].j'}, "x/y/strings.po", "de-DE"), "de/DE/tr-strings.j");
 
         test.done();
     },
@@ -130,7 +146,7 @@ module.exports.pofiletype = {
         var jft = new POFileType(p);
         test.ok(jft);
 
-        test.equals(jft.getLocalizedPath('[localeDir]/tr-[filename]', "x/y/strings.po", "de-DE"), "de/DE/tr-strings.po");
+        test.equals(jft.getLocalizedPath({template:'[localeDir]/tr-[filename]'}, "x/y/strings.po", "de-DE"), "de/DE/tr-strings.po");
 
         test.done();
     },
@@ -141,7 +157,7 @@ module.exports.pofiletype = {
         var jft = new POFileType(p);
         test.ok(jft);
 
-        test.equals(jft.getLocalizedPath('[localeDir]/tr-foobar.[extension]', "x/y/strings.jsn", "de-DE"), "de/DE/tr-foobar.jsn");
+        test.equals(jft.getLocalizedPath({template:'[localeDir]/tr-foobar.[extension]'}, "x/y/strings.jsn", "de-DE"), "de/DE/tr-foobar.jsn");
 
         test.done();
     },
@@ -152,7 +168,23 @@ module.exports.pofiletype = {
         var jft = new POFileType(p);
         test.ok(jft);
 
-        test.equals(jft.getLocalizedPath('[dir]/[locale]/strings.po', "x/y/strings.po", "de-DE"), "x/y/de-DE/strings.po");
+        test.equals(jft.getLocalizedPath({template:'[dir]/[locale]/strings.po'}, "x/y/strings.po", "de-DE"), "x/y/de-DE/strings.po");
+
+        test.done();
+    },
+
+    testPOFileTypeGetLocalizedPathLocaleWithLocaleMap: function(test) {
+        test.expect(2);
+
+        var jft = new POFileType(p);
+        test.ok(jft);
+
+        test.equals(jft.getLocalizedPath({
+            template: '[dir]/[locale]/strings.po',
+            localeMap: {
+                "de-DE": "de"
+            }
+        }, "x/y/strings.po", "de-DE"), "x/y/de/strings.po");
 
         test.done();
     },
@@ -163,7 +195,7 @@ module.exports.pofiletype = {
         var jft = new POFileType(p2);
         test.ok(jft);
 
-        test.equals(jft.getLocalizedPath('[dir]/[locale]/strings.po', "x/y/strings.po", "de-DE"), "x/y/de/strings.po");
+        test.equals(jft.getLocalizedPath({template:'[dir]/[locale]/strings.po'}, "x/y/strings.po", "de-DE"), "x/y/de/strings.po");
 
         test.done();
     },
@@ -174,7 +206,7 @@ module.exports.pofiletype = {
         var jft = new POFileType(p);
         test.ok(jft);
 
-        test.equals(jft.getLocalizedPath('[dir]/[language]/strings.po', "x/y/strings.po", "de-DE"), "x/y/de/strings.po");
+        test.equals(jft.getLocalizedPath({template:'[dir]/[language]/strings.po'}, "x/y/strings.po", "de-DE"), "x/y/de/strings.po");
 
         test.done();
     },
@@ -186,7 +218,7 @@ module.exports.pofiletype = {
         test.ok(jft);
 
         // no change
-        test.equals(jft.getLocalizedPath('[dir]/[language]/strings.po', "x/y/strings.po", "de-DE"), "x/y/de/strings.po");
+        test.equals(jft.getLocalizedPath({template:'[dir]/[language]/strings.po'}, "x/y/strings.po", "de-DE"), "x/y/de/strings.po");
 
         test.done();
     },
@@ -197,7 +229,7 @@ module.exports.pofiletype = {
         var jft = new POFileType(p);
         test.ok(jft);
 
-        test.equals(jft.getLocalizedPath('[dir]/[region]/strings.po', "x/y/strings.po", "de-DE"), "x/y/DE/strings.po");
+        test.equals(jft.getLocalizedPath({template:'[dir]/[region]/strings.po'}, "x/y/strings.po", "de-DE"), "x/y/DE/strings.po");
 
         test.done();
     },
@@ -209,7 +241,7 @@ module.exports.pofiletype = {
         test.ok(jft);
 
         // no region after the mapping, so it should skip the parts that don't exist
-        test.equals(jft.getLocalizedPath('[dir]/[region]/strings.po', "x/y/strings.po", "de-DE"), "x/y/strings.po");
+        test.equals(jft.getLocalizedPath({template:'[dir]/[region]/strings.po'}, "x/y/strings.po", "de-DE"), "x/y/strings.po");
 
         test.done();
     },
@@ -220,7 +252,7 @@ module.exports.pofiletype = {
         var jft = new POFileType(p);
         test.ok(jft);
 
-        test.equals(jft.getLocalizedPath('[dir]/[script]/strings.po', "x/y/strings.po", "zh-Hans-CN"), "x/y/Hans/strings.po");
+        test.equals(jft.getLocalizedPath({template:'[dir]/[script]/strings.po'}, "x/y/strings.po", "zh-Hans-CN"), "x/y/Hans/strings.po");
 
         test.done();
     },
@@ -231,7 +263,23 @@ module.exports.pofiletype = {
         var jft = new POFileType(p);
         test.ok(jft);
 
-        test.equals(jft.getLocalizedPath('[dir]/strings_[localeUnder].po', "x/y/strings.po", "zh-Hans-CN"), "x/y/strings_zh_Hans_CN.po");
+        test.equals(jft.getLocalizedPath({template:'[dir]/strings_[localeUnder].po'}, "x/y/strings.po", "zh-Hans-CN"), "x/y/strings_zh_Hans_CN.po");
+
+        test.done();
+    },
+
+    testPOFileTypeGetLocalizedPathLocaleUnderWithLocaleMap: function(test) {
+        test.expect(2);
+
+        var jft = new POFileType(p);
+        test.ok(jft);
+
+        test.equals(jft.getLocalizedPath({
+            template: '[dir]/strings_[localeUnder].po',
+            localeMap: {
+                "zh-Hans-CN": "zh-CN"
+            }
+        }, "x/y/strings.po", "zh-Hans-CN"), "x/y/strings_zh_CN.po");
 
         test.done();
     },

--- a/test/testfiles/po/foo.po
+++ b/test/testfiles/po/foo.po
@@ -1,0 +1,24 @@
+#, fuzzy
+msgid ""
+msgstr ""
+"#-#-#-#-#  messages.pot  #-#-#-#-#\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: loctool\n"
+"Project-Id-Version: 1\n"
+
+#: a/b/c.js:32
+msgid "string 1"
+msgstr ""
+
+# a plural string
+msgid "one string"
+msgid_plural "{$count} strings"
+
+# another string
+msgid "string 2"
+
+# string with continuation
+msgid ""
+"string 3 "
+"and 4"


### PR DESCRIPTION
- Added the ability to specify a locale map in the file name template mapping. This allows for different locale specifications for different sets of output files, which may be necessary if those output files are intended to be used in different programming languages or on different platforms that support a different set of locales.