### PR TITLE
Make sure the header locale spec is correct

### DIFF
--- a/POFile.js
+++ b/POFile.js
@@ -617,7 +617,7 @@ function objectMap(object, visitor) {
  * @returns {String} the localized text of this file
  */
 POFile.prototype.localizeText = function(translations, locale) {
-    var l = new Locale((this.mapping && this.mapping.localeMap && this.mapping.localeMap[locale]) || this.project.getOutputLocale(locale));
+    var l = this.type.getOutputLocale(this.mapping, locale);
     var plurals = pluralForms[l.getLanguage()] || pluralForms.en;
     var pluralCategories = plurals.categories;
 

--- a/POFile.js
+++ b/POFile.js
@@ -617,7 +617,7 @@ function objectMap(object, visitor) {
  * @returns {String} the localized text of this file
  */
 POFile.prototype.localizeText = function(translations, locale) {
-    var l = new Locale(locale);
+    var l = new Locale((this.mapping && this.mapping.localeMap && this.mapping.localeMap[locale]) || this.project.getOutputLocale(locale));
     var plurals = pluralForms[l.getLanguage()] || pluralForms.en;
     var pluralCategories = plurals.categories;
 
@@ -630,7 +630,7 @@ POFile.prototype.localizeText = function(translations, locale) {
         '"Content-Transfer-Encoding: 8bit\\n"\n' +
         '"Generated-By: loctool\\n"\n' +
         '"Project-Id-Version: 1\\n"\n' +
-        '"Language: ' + locale + '\\n"\n' +
+        '"Language: ' + l.getSpec() + '\\n"\n' +
         '"Plural-Forms: ' + plurals.rules + '\\n"\n';
 
     if (resources) {

--- a/POFileType.js
+++ b/POFileType.js
@@ -268,6 +268,18 @@ POFileType.prototype.getLocaleFromPath = function(template, pathname) {
 };
 
 /**
+ * Return the alternate output locale or the shared output locale for the given
+ * mapping. If there are no locale mappings, it returns the locale parameter.
+ *
+ * @param {Object} mapping the mapping for this source file
+ * @param {String} locale the locale spec for the target locale
+ * @returns {Locale} the output locale
+ */
+POFileType.prototype.getOutputLocale = function(mapping, locale) {
+    return new Locale((mapping && mapping.localeMap && mapping.localeMap[locale]) || this.project.getOutputLocale(locale));
+};
+
+/**
  * Return the location on disk where the version of this file localized
  * for the given locale should be written.
  * @param {Object} mapping the mapping for this source file
@@ -278,7 +290,7 @@ POFileType.prototype.getLocaleFromPath = function(template, pathname) {
 POFileType.prototype.getLocalizedPath = function(mapping, pathname, locale) {
     var output = "";
     var template = mapping && mapping.template;
-    var l = new Locale((mapping && mapping.localeMap && mapping.localeMap[locale]) || this.project.getOutputLocale(locale));
+    var l = this.getOutputLocale(mapping, locale);
 
     if (!template) {
         template = defaultMappings["**/*.po"].template;

--- a/README.md
+++ b/README.md
@@ -226,6 +226,11 @@ file for more details.
 
 ## Release Notes
 
+### v1.4.1
+
+- Fixed the po header output so that it shows the locale spec of the mapped
+  output locale, not of the source locale.
+
 ### v1.4.0
 
 - added the ability to ignore comments. This solves the problem where file names

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-po",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "main": "./POFileType.js",
     "description": "A loctool plugin that knows how to localize GNU po and pot files",
     "license": "Apache-2.0",
@@ -54,12 +54,12 @@
         "node": ">=6.0"
     },
     "dependencies": {
-        "ilib": "^14.7.0",
+        "ilib": "^14.9.2",
         "log4js": "^2.11.0"
     },
     "devDependencies": {
         "assertextras": "^1.1.0",
-        "loctool": "^2.13.0",
+        "loctool": "^2.14.1",
         "nodeunit": "^0.11.3"
     }
 }

--- a/test/testPOFile.js
+++ b/test/testPOFile.js
@@ -2190,6 +2190,87 @@ module.exports.pofile = {
         test.done();
     },
 
+    testPOFileLocalizeWithAlternateLocaleMappingRightContents: function(test) {
+        test.expect(4);
+
+        var base = path.dirname(module.id);
+
+        if (fs.existsSync(path.join(base, "./testfiles/po/no.po"))) {
+            fs.unlinkSync(path.join(base, "./testfiles/po/no.po"));
+        }
+
+        test.ok(!fs.existsSync(path.join(base, "./testfiles/po/no.po")));
+
+        var pof = new POFile({
+            project: p,
+            pathName: "./po/foo.po",
+            type: t
+        });
+        test.ok(pof);
+
+        // should read the file
+        pof.extract();
+
+        var translations = new TranslationSet();
+        translations.add(new ContextResourceString({
+            project: "foo",
+            key: "string 1",
+            source: "string 1",
+            sourceLocale: "en-US",
+            target: "streng en",
+            targetLocale: "nb-NO",
+            datatype: "po"
+        }));
+        translations.add(new ContextResourceString({
+            project: "foo",
+            key: "string 2",
+            source: "string 2",
+            sourceLocale: "en-US",
+            target: "streng to",
+            targetLocale: "nb-NO",
+            datatype: "po"
+        }));
+
+        // should use the locale map in the mapping rather than the shared one
+        pof.localize(translations, ["nb-NO"]);
+
+        test.ok(fs.existsSync(path.join(base, "./testfiles/po/no.po")));
+
+        var actual = fs.readFileSync(path.join(base, "./testfiles/po/no.po"), "utf-8");
+        var expected =
+            'msgid ""\n' +
+            'msgstr ""\n' +
+            '"#-#-#-#-#  ./po/foo.po  #-#-#-#-#\\n"\n' +
+            '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
+            '"Content-Transfer-Encoding: 8bit\\n"\n' +
+            '"Generated-By: loctool\\n"\n' +
+            '"Project-Id-Version: 1\\n"\n' +
+            '"Language: no\\n"\n' +
+            '"Plural-Forms: nplurals=2; plural=n != 1;\\n"\n' +
+            '\n' +
+            '#: a/b/c.js:32\n' +
+            'msgid "string 1"\n' +
+            'msgstr "streng en"\n' +
+            '\n' +
+            '# a plural string\n' +
+            'msgid "one string"\n' +
+            'msgid_plural "{$count} strings"\n' +
+            'msgstr[0] ""\n' +
+            'msgstr[1] ""\n' +
+            '\n' +
+            '# another string\n' +
+            'msgid "string 2"\n' +
+            'msgstr "streng to"\n' +
+            '\n' +
+            '# string with continuation\n' +
+            'msgid "string 3 and 4"\n' +
+            'msgstr ""\n\n';
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
     testPOFileLocalizeWithSharedLocaleMapping: function(test) {
         test.expect(3);
 
@@ -2217,6 +2298,88 @@ module.exports.pofile = {
         pof.localize(translations, ["nb-NO"]);
 
         test.ok(fs.existsSync(path.join(base, "testfiles/resources/template_nb.po")));
+
+        test.done();
+    },
+
+    testPOFileLocalizeWithSharedLocaleMappingRightContents: function(test) {
+        test.expect(4);
+
+        var base = path.dirname(module.id);
+
+        if (fs.existsSync(path.join(base, "testfiles/resources/template_nb.po"))) {
+            fs.unlinkSync(path.join(base, "testfiles/resources/template_nb.po"));
+        }
+
+        test.ok(!fs.existsSync(path.join(base, "testfiles/resources/template_nb.po")));
+
+        var pof = new POFile({
+            project: p,
+            pathName: "./po/template.po",
+            type: t
+        });
+        test.ok(pof);
+
+        // should read the file
+        pof.extract();
+
+        var translations = new TranslationSet();
+        translations.add(new ContextResourceString({
+            project: "foo",
+            key: "string 1",
+            source: "string 1",
+            sourceLocale: "en-US",
+            target: "streng en",
+            targetLocale: "nb-NO",
+            datatype: "po"
+        }));
+        translations.add(new ContextResourceString({
+            project: "foo",
+            key: "string 2",
+            source: "string 2",
+            sourceLocale: "en-US",
+            target: "streng to",
+            targetLocale: "nb-NO",
+            datatype: "po"
+        }));
+
+        // should use the shared locale map because there isn't one in the mapping
+        pof.localize(translations, ["nb-NO"]);
+
+        test.ok(fs.existsSync(path.join(base, "testfiles/resources/template_nb.po")));
+
+        var actual = fs.readFileSync(path.join(base, "testfiles/resources/template_nb.po"), "utf-8");
+        var expected =
+            'msgid ""\n' +
+            'msgstr ""\n' +
+            '"#-#-#-#-#  ./po/template.po  #-#-#-#-#\\n"\n' +
+            '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
+            '"Content-Transfer-Encoding: 8bit\\n"\n' +
+            '"Generated-By: loctool\\n"\n' +
+            '"Project-Id-Version: 1\\n"\n' +
+            '"Language: nb\\n"\n' +
+            '"Plural-Forms: nplurals=2; plural=n != 1;\\n"\n' +
+            '\n' +
+            '#: a/b/c.js:32\n' +
+            'msgid "string 1"\n' +
+            'msgstr "streng en"\n' +
+            '\n' +
+            '# a plural string\n' +
+            'msgid "one string"\n' +
+            'msgid_plural "{$count} strings"\n' +
+            'msgstr[0] ""\n' +
+            'msgstr[1] ""\n' +
+            '\n' +
+            '# another string\n' +
+            'msgid "string 2"\n' +
+            'msgstr "streng to"\n' +
+            '\n' +
+            '# string with continuation\n' +
+            'msgid "string 3 and 4"\n' +
+            'msgstr ""\n\n';
+        diff(actual, expected);
+        test.equal(actual, expected);
+
 
         test.done();
     },


### PR DESCRIPTION
Previously, it was using the translation locale before the output
mapping. Now it uses the locale after the mapping.