### PR TITLE
Fix a bug in the getOutputLocale function

### DIFF
--- a/POFileType.js
+++ b/POFileType.js
@@ -279,7 +279,10 @@ POFileType.prototype.getOutputLocale = function(mapping, locale) {
     // we can remove the replace() call after upgrading to
     // ilib 14.10.0 or later because it can parse locale specs
     // with underscores in them
-    return new Locale((mapping && mapping.localeMap && mapping.localeMap[locale].replace(/_/g, '-')) || this.project.getOutputLocale(locale));
+    return new Locale(
+        (mapping && mapping.localeMap && mapping.localeMap[locale] && 
+         mapping.localeMap[locale].replace(/_/g, '-')) || 
+        this.project.getOutputLocale(locale));
 };
 
 /**

--- a/README.md
+++ b/README.md
@@ -231,6 +231,11 @@ file for more details.
 
 ## Release Notes
 
+### v1.5.1
+
+- fixed a bug in the getOutputLocale function when you are missing a
+  locale in the localeMap that is mentioned in the list of locales
+
 ### v1.5.0
 
 - Added headerLocale setting to the mappings. This allows you to specify

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-po",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "main": "./POFileType.js",
     "description": "A loctool plugin that knows how to localize GNU po and pot files",
     "license": "Apache-2.0",


### PR DESCRIPTION
If you had a locale that was mentioned in the list of locales and didn't put it in the localeMap, it would cause an exception.