### PR TITLE
Add contextInKey feature

### DIFF
--- a/POFile.js
+++ b/POFile.js
@@ -304,12 +304,13 @@ POFile.prototype.parse = function(data) {
                     case tokens.BLANKLINE:
                         if (source || sourcePlurals) {
                             // emit a resource
-                            var options;
+                            var options, key;
                             if (sourcePlurals) {
+                                key = (context && this.mapping && this.mapping.contextInKey) ? sourcePlurals.one + " --- " + context : sourcePlurals.one;
                                 options = {
                                     resType: "plural",
                                     project: this.project.getProjectId(),
-                                    key: source,
+                                    key: key,
                                     sourceLocale: this.project.sourceLocale,
                                     sourceStrings: sourcePlurals,
                                     pathName: original,
@@ -324,10 +325,11 @@ POFile.prototype.parse = function(data) {
                                     options.targetStrings = translationPlurals;
                                 }
                             } else {
+                                key = (context && this.mapping && this.mapping.contextInKey) ? source + " --- " + context : source;
                                 options = {
                                     resType: "string",
                                     project: this.project.getProjectId(),
-                                    key: source,
+                                    key: key,
                                     sourceLocale: this.project.sourceLocale,
                                     source: source,
                                     pathName: original,
@@ -626,6 +628,10 @@ POFile.prototype.localizeText = function(translations, locale) {
         for (var i = 0; i < resources.length; i++) {
             var r = resources[i];
             var key = r.getKey();
+            if (this.mapping && this.mapping.contextInKey && r.getContext()) {
+                // strip off the context built into the key
+                key = r.getKey().replace(/ --- .*$/, '');
+            }
             output += '\n';
             var c = r.getComment() ? JSON.parse(r.getComment()) : {};
 
@@ -685,7 +691,7 @@ POFile.prototype.localizeText = function(translations, locale) {
                                 this.type.newres.add(this.API.newResource({
                                     resType: "string",
                                     project: r.getProject(),
-                                    key: key,
+                                    key: r.getKey(),
                                     sourceLocale: r.getSourceLocale(),
                                     source: text,
                                     targetLocale: locale,
@@ -751,7 +757,7 @@ POFile.prototype.localizeText = function(translations, locale) {
                                 this.type.newres.add(this.API.newResource({
                                     resType: "plural",
                                     project: r.getProject(),
-                                    key: key,
+                                    key: r.getKey(),
                                     sourceLocale: r.getSourceLocale(),
                                     sourceStrings: sourcePlurals,
                                     targetLocale: locale,

--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ used within the po property:
         - *full*: put the fully specified locale spec in the header
         - *abbreviated*: put an abbreviated locale spec in the header (language only)
         - *mapped*: put the results of the output locale mapping (see above) into the header
+    - contextInKey: some translation management systems cannot support separate context
+      fields, and therefore two translation units that only differ in their context cannot
+      be distinguished from each other. If this setting is set to "true", then the context
+      is added to the key for a unit. eg. if the string is "Sent" and the context is "Email",
+      a translation unit will be produced with the key "Sent --- Email" and the source string
+      is "Sent".
 
 Example configuration:
 
@@ -230,6 +236,14 @@ This plugin is license under Apache2. See the [LICENSE](./LICENSE)
 file for more details.
 
 ## Release Notes
+
+### v1.6.0
+
+- added the contextInKey setting so that we can support translation
+  management systems that do not support contexts. Instead, we add the context
+  to the key for each translation unit, so that two translations units
+  that differ only in their context can still be dinstinguished from each
+  other.
 
 ### v1.5.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-po",
-    "version": "1.5.1",
+    "version": "1.6.0",
     "main": "./POFileType.js",
     "description": "A loctool plugin that knows how to localize GNU po and pot files",
     "license": "Apache-2.0",


### PR DESCRIPTION
- Add contextInKey setting in the mappings to support translation management systems that do not support context (ie. mojito).
- Follows conventions that mojito itself follows for representing context